### PR TITLE
sampling for successful call results

### DIFF
--- a/gun_sleep_mock.go
+++ b/gun_sleep_mock.go
@@ -48,8 +48,7 @@ func (m *MockGun) Call(l *Generator) CallResult {
 		//nolint
 		r := rand.Intn(100)
 		if r <= m.cfg.TimeoutRatio {
-			time.Sleep(m.cfg.CallSleep + 100*time.Millisecond)
-			return CallResult{Data: "timeoutCallData", Timeout: true}
+			time.Sleep(m.cfg.CallSleep + 20*time.Millisecond)
 		}
 	}
 	return CallResult{Data: "successCallData"}

--- a/perf_test.go
+++ b/perf_test.go
@@ -85,13 +85,14 @@ func TestRenderLokiRPSRun(t *testing.T) {
 		gen, err := NewGenerator(&Config{
 			T:          t,
 			LokiConfig: NewEnvLokiConfig(),
+			GenName:    "rps",
 			Labels: map[string]string{
-				"branch":   "generator_healthcheck",
-				"commit":   "generator_healthcheck",
-				"gen_name": "rps",
+				"branch": "generator_healthcheck",
+				"commit": "generator_healthcheck",
 			},
-			CallTimeout: 100 * time.Millisecond,
-			LoadType:    RPS,
+			SamplerConfig: &SamplerConfig{SuccessfulCallResultRecordRatio: 50},
+			CallTimeout:   100 * time.Millisecond,
+			LoadType:      RPS,
 			Schedule: CombineAndRepeat(
 				2,
 				Line(1, 100, 30*time.Second),
@@ -115,13 +116,14 @@ func TestRenderLokiVUsRun(t *testing.T) {
 		gen, err := NewGenerator(&Config{
 			T:          t,
 			LokiConfig: NewEnvLokiConfig(),
+			GenName:    "vu",
 			Labels: map[string]string{
-				"branch":   "generator_healthcheck",
-				"commit":   "generator_healthcheck",
-				"gen_name": "vu",
+				"branch": "generator_healthcheck",
+				"commit": "generator_healthcheck",
 			},
-			CallTimeout: 100 * time.Millisecond,
-			LoadType:    VU,
+			CallTimeout:   100 * time.Millisecond,
+			LoadType:      VU,
+			SamplerConfig: &SamplerConfig{SuccessfulCallResultRecordRatio: 50},
 			Schedule: CombineAndRepeat(
 				2,
 				Line(1, 20, 30*time.Second),
@@ -129,7 +131,8 @@ func TestRenderLokiVUsRun(t *testing.T) {
 				Line(20, 1, 30*time.Second),
 			),
 			VU: NewMockVU(&MockVirtualUserConfig{
-				CallSleep: 150 * time.Millisecond,
+				TimeoutRatio: 1,
+				CallSleep:    50 * time.Millisecond,
 			}),
 		})
 		require.NoError(t, err)

--- a/vu_sleep_mock.go
+++ b/vu_sleep_mock.go
@@ -61,8 +61,7 @@ func (m *MockVirtualUser) Call(l *Generator) {
 		//nolint
 		r := rand.Intn(100)
 		if r <= m.cfg.TimeoutRatio {
-			time.Sleep(m.cfg.CallSleep + 100*time.Millisecond)
-			l.ResponsesChan <- CallResult{StartedAt: &startedAt, Data: "timeoutData", Timeout: true}
+			time.Sleep(m.cfg.CallSleep + 20*time.Millisecond)
 		}
 	}
 	l.ResponsesChan <- CallResult{StartedAt: &startedAt, Data: "successCallData"}


### PR DESCRIPTION
Now you can use `SamplerConfig` to skip some successful samples for cluster runs. Each `Generator` can skip some percentage of successful `CallResult` responses.
<img width="1740" alt="image" src="https://github.com/smartcontractkit/wasp/assets/14962379/83bee1c1-4ed6-4363-a5a9-170b8cdcff10">
