### PR TITLE
use only loki.StopNow to avoid deadlocks

### DIFF
--- a/loki_client.go
+++ b/loki_client.go
@@ -3,6 +3,7 @@ package wasp
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
 	"time"
 
@@ -148,8 +149,12 @@ func NewEnvLokiConfig() *LokiConfig {
 
 // NewLokiClient creates a new Promtail client
 func NewLokiClient(extCfg *LokiConfig) (*LokiClient, error) {
+	_, err := http.Get(extCfg.URL)
+	if err != nil {
+		return nil, err
+	}
 	serverURL := dskit.URLValue{}
-	err := serverURL.Set(extCfg.URL)
+	err = serverURL.Set(extCfg.URL)
 	if err != nil {
 		return nil, err
 	}

--- a/loki_client_test.go
+++ b/loki_client_test.go
@@ -17,6 +17,28 @@ func lokiLogTupleMsg() []interface{} {
 	return logMsg
 }
 
+func TestSmokeDefaultLokiConfig(t *testing.T) {
+	cfg := NewEnvLokiConfig()
+	cfg.MaxErrors = 1
+	lc, err := NewLokiClient(cfg)
+	defer lc.StopNow()
+	require.NoError(t, err)
+	q := struct {
+		Name string
+	}{
+		Name: "test",
+	}
+	var errAtSomePoint error
+	for i := 0; i < 10; i++ {
+		time.Sleep(1 * time.Second)
+		errAtSomePoint = lc.HandleStruct(nil, time.Now(), q)
+		if errAtSomePoint != nil {
+			return
+		}
+	}
+	require.Error(t, err)
+}
+
 func TestSmokeLokiErrors(t *testing.T) {
 	type testcase struct {
 		name      string

--- a/perf_test.go
+++ b/perf_test.go
@@ -12,8 +12,9 @@ import (
 	"runtime"
 
 	"fmt"
-	"github.com/pyroscope-io/client/pyroscope"
 	"net/http/httptest"
+
+	"github.com/pyroscope-io/client/pyroscope"
 )
 
 /* This tests can also be used as a performance validation of a tool itself or as a dashboard data filler */

--- a/wasp.go
+++ b/wasp.go
@@ -673,7 +673,7 @@ func (g *Generator) Stats() *Stats {
 func (g *Generator) stopLokiStream() {
 	if g.cfg.LokiConfig != nil && g.cfg.LokiConfig.URL != "" {
 		g.Log.Info().Msg("Stopping Loki")
-		g.loki.Stop()
+		g.loki.StopNow()
 		g.Log.Info().Msg("Loki exited")
 	}
 }


### PR DESCRIPTION
- Use `StopNow()` to avoid deadlocks
- Return error if URL is not resolving, since we can't prevent writing to a write-only channel we do not control