### PR TITLE
Add common wasp panels that use Grafana SDK

### DIFF
--- a/dashboard/grafanasdk/panels.go
+++ b/dashboard/grafanasdk/panels.go
@@ -1,0 +1,381 @@
+package grafanasdk
+
+import (
+	"github.com/grafana/grafana-foundation-sdk/go/common"
+	"github.com/grafana/grafana-foundation-sdk/go/dashboard"
+	"github.com/grafana/grafana-foundation-sdk/go/logs"
+	"github.com/grafana/grafana-foundation-sdk/go/prometheus"
+	"github.com/grafana/grafana-foundation-sdk/go/stat"
+	"github.com/grafana/grafana-foundation-sdk/go/timeseries"
+)
+
+func RPSNowPanel(queryPrefix string, panelID uint32, datasource dashboard.DataSourceRef) *stat.PanelBuilder {
+	panelName := "RPS (Now)"
+	query := `sum(last_over_time({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"}
+	| json
+	| unwrap current_rps [1s]) by (node_id, go_test_name, gen_name)) by (__stream_shard__)`
+	legend := "{{go_test_name}} {{gen_name}} RPS"
+
+	return stat.NewPanelBuilder().Title(panelName).
+		Id(panelID).
+		Datasource(datasource).
+		Orientation(common.VizOrientationVertical).
+		Text(common.NewVizTextDisplayOptionsBuilder().TitleSize(12).ValueSize(20)).
+		TextMode(common.BigValueTextModeValueAndName).
+		GraphMode(common.BigValueGraphModeNone).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().Mode(dashboard.ThresholdsModeAbsolute).Steps([]dashboard.Threshold{})).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"last"}).Values(false)).
+		Span(2).
+		Height(6).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(query).
+				Format("time_series").
+				LegendFormat(legend),
+		)
+}
+
+func VUsNowPanel(queryPrefix string, panelID uint32, datasource dashboard.DataSourceRef) *stat.PanelBuilder {
+	panelName := "VUs (Now)"
+	query := `sum(max_over_time({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"}
+	| json
+	| unwrap current_instances [$__range]) by (node_id, go_test_name, gen_name)) by (__stream_shard__)`
+	legend := "{{go_test_name}} {{gen_name}} VUs"
+
+	return stat.NewPanelBuilder().Title(panelName).
+		Id(panelID).
+		Datasource(datasource).
+		Orientation(common.VizOrientationVertical).
+		Text(common.NewVizTextDisplayOptionsBuilder().TitleSize(12).ValueSize(20)).
+		TextMode(common.BigValueTextModeValueAndName).
+		GraphMode(common.BigValueGraphModeNone).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().Mode(dashboard.ThresholdsModeAbsolute).Steps([]dashboard.Threshold{})).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"last"}).Values(false)).
+		Span(2).
+		Height(6).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(query).
+				Format("time_series").
+				LegendFormat(legend),
+		)
+}
+
+func ResponsesPerSecNowPanel(queryPrefix string, panelID uint32, datasource dashboard.DataSourceRef) *stat.PanelBuilder {
+	panelName := "Responses/sec (Now)"
+	query := `sum(count_over_time({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} [1s])) by (node_id, go_test_name, gen_name)`
+	legend := "{{go_test_name}} {{gen_name}} Responses/sec"
+
+	return stat.NewPanelBuilder().Title(panelName).
+		Id(panelID).
+		Datasource(datasource).
+		Orientation(common.VizOrientationHorizontal).
+		Text(common.NewVizTextDisplayOptionsBuilder().TitleSize(12).ValueSize(12)).
+		TextMode(common.BigValueTextModeValueAndName).
+		GraphMode(common.BigValueGraphModeNone).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().Mode(dashboard.ThresholdsModeAbsolute).Steps([]dashboard.Threshold{})).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"last"}).Values(false)).
+		Span(8).
+		Height(6).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(query).
+				Format("time_series").
+				LegendFormat(legend),
+		)
+}
+
+func TotalSuccessfulRequestsPanel(queryPrefix string, panelID uint32, datasource dashboard.DataSourceRef) *stat.PanelBuilder {
+	panelName := "Successful requests (Total)"
+	query := `
+	sum(max_over_time({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"}
+	| json
+	| unwrap success [$__range]) by (node_id, go_test_name, gen_name)) by (__stream_shard__)
+	`
+	legend := "{{go_test_name}} {{gen_name}} Successful requests"
+
+	return stat.NewPanelBuilder().Title(panelName).
+		Id(panelID).
+		Datasource(datasource).
+		Orientation(common.VizOrientationVertical).
+		Text(common.NewVizTextDisplayOptionsBuilder().TitleSize(12).ValueSize(20)).
+		TextMode(common.BigValueTextModeValueAndName).
+		GraphMode(common.BigValueGraphModeNone).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().Mode(dashboard.ThresholdsModeAbsolute).Steps([]dashboard.Threshold{})).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"last"}).Values(false)).
+		Span(4).
+		Height(6).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(query).
+				Format("time_series").
+				LegendFormat(legend),
+		)
+}
+
+func TotalErroredRequestsPanel(queryPrefix string, panelID uint32, datasource dashboard.DataSourceRef) *stat.PanelBuilder {
+	panelName := "Errored requests (Total)"
+	query := `
+	sum(max_over_time({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"}
+	| json
+	| unwrap failed [$__range]) by (node_id, go_test_name, gen_name)) by (__stream_shard__)
+	`
+	legend := "{{go_test_name}} {{gen_name}} Errored requests"
+
+	return stat.NewPanelBuilder().Title(panelName).
+		Id(panelID).
+		Datasource(datasource).
+		Orientation(common.VizOrientationVertical).
+		Text(common.NewVizTextDisplayOptionsBuilder().TitleSize(12).ValueSize(20)).
+		TextMode(common.BigValueTextModeValueAndName).
+		GraphMode(common.BigValueGraphModeNone).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().Mode(dashboard.ThresholdsModeAbsolute).Steps([]dashboard.Threshold{})).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"last"}).Values(false)).
+		Span(4).
+		Height(6).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(query).
+				Format("time_series").
+				LegendFormat(legend),
+		)
+}
+
+func TimedOutRequestsPanel(queryPrefix string, panelID uint32, datasource dashboard.DataSourceRef) *stat.PanelBuilder {
+	panelName := "Timed out requests (Total)"
+	query := `
+	sum(max_over_time({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"}
+	| json
+	| unwrap callTimeout [$__range]) by (node_id, go_test_name, gen_name)) by (__stream_shard__)
+	`
+	legend := "{{go_test_name}} {{gen_name}} Timed out requests"
+
+	return stat.NewPanelBuilder().Title(panelName).
+		Id(panelID).
+		Datasource(datasource).
+		Orientation(common.VizOrientationVertical).
+		Text(common.NewVizTextDisplayOptionsBuilder().TitleSize(12).ValueSize(20)).
+		TextMode(common.BigValueTextModeValueAndName).
+		GraphMode(common.BigValueGraphModeNone).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().Mode(dashboard.ThresholdsModeAbsolute).Steps([]dashboard.Threshold{})).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"last"}).Values(false)).
+		Span(4).
+		Height(6).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(query).
+				Format("time_series").
+				LegendFormat(legend),
+		)
+}
+
+func LatestSegmentStatPanel(queryPrefix string, panelID uint32, datasource dashboard.DataSourceRef) *stat.PanelBuilder {
+	return stat.NewPanelBuilder().Title("Latest segment stats").
+		Id(panelID).
+		Datasource(datasource).
+		Orientation(common.VizOrientationVertical).
+		Text(common.NewVizTextDisplayOptionsBuilder().TitleSize(12).ValueSize(20)).
+		TextMode(common.BigValueTextModeValueAndName).
+		GraphMode(common.BigValueGraphModeNone).
+		ReduceOptions(common.NewReduceDataOptionsBuilder().Calcs([]string{"last"}).Values(true)).
+		Span(24).
+		Height(6).
+		ColorMode(common.BigValueColorModeValue).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(bytes_over_time({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", gen_name=~"${gen_name:pipe}"} [$__range]) * 1e-6)`).
+				LegendFormat("Overall logs size"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(bytes_rate({` + queryPrefix + `go_test_name=~"${go_test_name:pipe}", gen_name=~"${gen_name:pipe}"} [$__interval]) * 1e-6)`).
+				LegendFormat("{{go_test_name}} {{gen_name}} Timed out requests"),
+		)
+}
+
+func RPSPanel(queryString string, panelID uint32, promDatasource dashboard.DataSourceRef) *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().Title("Responses/sec (Generator, CallGroup)").
+		Id(panelID).
+		Datasource(promDatasource).
+		Height(8).
+		Span(12).
+		Transparent(true).
+		GradientMode(common.GraphGradientModeOpacity).
+		FillOpacity(25).
+		AxisLabel("Responses").
+		Legend(common.NewVizLegendOptionsBuilder().ShowLegend(true).Placement(common.LegendPlacementBottom).DisplayMode(common.LegendDisplayModeList).Calcs([]string{})).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(count_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}", call_group=~"${call_group:pipe}"} [1s])) by (node_id, go_test_name, gen_name, call_group)`).
+				LegendFormat("{{go_test_name}} {{gen_name}} {{call_group}} responses/sec"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(count_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} [1s])) by (node_id, go_test_name, gen_name)`).
+				LegendFormat("{{go_test_name}} Total responses/sec"),
+		)
+}
+
+func RPSVUPerScheduleSegmentsPanel(queryString string, panelID uint32, datasource dashboard.DataSourceRef) *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().Title("RPS/VUs per schedule segments").
+		Id(panelID).
+		Datasource(datasource).
+		Height(8).
+		Span(12).
+		Transparent(true).
+		FillOpacity(25).
+		GradientMode(common.GraphGradientModeOpacity).
+		ShowPoints("").
+		Stacking(common.NewStackingConfigBuilder().Group("").Mode("")).
+		LineStyle(common.NewLineStyleBuilder().Fill(common.LineStyleFillSolid)).
+		Thresholds(dashboard.NewThresholdsConfigBuilder().Mode(dashboard.ThresholdsModeAbsolute).Steps([]dashboard.Threshold{})).
+		ThresholdsStyle(common.NewGraphThresholdsStyleConfigBuilder().Mode("")).
+		Tooltip(common.NewVizTooltipOptionsBuilder().Mode(common.TooltipDisplayModeSingle).Sort(common.SortOrderNone)).
+		Unit("").
+		Legend(common.NewVizLegendOptionsBuilder().ShowLegend(true).Placement(common.LegendPlacementBottom).DisplayMode(common.LegendDisplayModeList).Calcs([]string{})).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`max_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"} | json | unwrap current_rps [$__interval]) by (node_id, go_test_name, gen_name)`).
+				Format("time_series").
+				LegendFormat("{{go_test_name}} {{gen_name}} RPS"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(last_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"} | json | unwrap current_rps [$__interval]) by (node_id, go_test_name, gen_name))`).
+				Format("time_series").
+				LegendFormat("{{go_test_name}} Total RPS"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`max_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"} | json | unwrap current_instances [$__interval]) by (node_id, go_test_name, gen_name)`).
+				Format("time_series").
+				LegendFormat("{{go_test_name}} {{gen_name}} VUs"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(last_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"} | json | unwrap current_instances [$__interval]) by (node_id, go_test_name, gen_name))`).
+				Format("time_series").
+				LegendFormat("{{go_test_name}} Total VUs"),
+		)
+}
+
+func LatencyQuantilesPanel(queryString string, panelID uint32, promDatasource dashboard.DataSourceRef) *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().Title("Latency quantiles over groups (99, 95, 50)").
+		Id(panelID).
+		Datasource(promDatasource).
+		Height(8).
+		Span(12).
+		Transparent(true).
+		AxisLabel("ms").
+		Legend(common.NewVizLegendOptionsBuilder().ShowLegend(true).Placement(common.LegendPlacementBottom).DisplayMode(common.LegendDisplayModeList).Calcs([]string{})).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`quantile_over_time(0.99, {` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} | json | unwrap duration [$__interval]) by (go_test_name, gen_name) / 1e6`).
+				LegendFormat("{{go_test_name}} {{gen_name}} Q 99 - {{error}}"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`quantile_over_time(0.95, {` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} | json | unwrap duration [$__interval]) by (go_test_name, gen_name) / 1e6`).
+				LegendFormat("{{go_test_name}} {{gen_name}} Q 95 - {{error}}"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`quantile_over_time(0.50, {` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} | json | unwrap duration [$__interval]) by (go_test_name, gen_name) / 1e6`).
+				LegendFormat("{{go_test_name}} {{gen_name}} Q 50 - {{error}}"),
+		)
+}
+
+func ResponseLatenciesPanel(queryString string, panelID uint32, promDatasource dashboard.DataSourceRef) *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().Title("Responses latencies by types over time (Generator, CallGroup)").
+		Id(panelID).
+		Datasource(promDatasource).
+		Height(8).
+		Span(12).
+		Transparent(true).
+		AxisLabel("ms").
+		Legend(common.NewVizLegendOptionsBuilder().ShowLegend(true).Placement(common.LegendPlacementBottom).DisplayMode(common.LegendDisplayModeList).Calcs([]string{})).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`last_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}", call_group=~"${call_group}"} | json | unwrap duration [$__interval]) / 1e6`).
+				LegendFormat("{{go_test_name}} {{gen_name}} {{call_group}} T: {{timeout}} E: {{error}}"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`last_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} | json | unwrap duration [$__interval]) / 1e6`).
+				LegendFormat("{{go_test_name}} {{gen_name}} all groups T: {{timeout}} E: {{error}}"),
+		)
+}
+
+func CallResultSamplingPanel(queryString string, panelID uint32, promDatasource dashboard.DataSourceRef) *timeseries.PanelBuilder {
+	return timeseries.NewPanelBuilder().
+		Title("CallResult sampling (successful results)").
+		Id(panelID).
+		Datasource(promDatasource).
+		Height(6).
+		Span(24).
+		Transparent(true).
+		AxisLabel("CallResults").
+		Legend(common.NewVizLegendOptionsBuilder().ShowLegend(true).Placement(common.LegendPlacementBottom).DisplayMode(common.LegendDisplayModeList).Calcs([]string{})).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(last_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"} | json | unwrap samples_recorded [$__interval])) by (go_test_name, gen_name)`).
+				LegendFormat("{{go_test_name}} {{gen_name}} recorded"),
+		).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`sum(last_over_time({` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"} | json | unwrap samples_skipped [$__interval])) by (go_test_name, gen_name)`).
+				LegendFormat("{{go_test_name}} {{gen_name}} skipped"),
+		)
+}
+
+func StatsLogsPanel(queryString string, panelID uint32, promDatasource dashboard.DataSourceRef) *logs.PanelBuilder {
+	return logs.NewPanelBuilder().
+		Title("Stats logs").
+		Id(panelID).
+		Datasource(promDatasource).
+		Height(8).
+		Span(24).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`{` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"stats", gen_name=~"${gen_name:pipe}"}`).
+				LegendFormat("__auto"),
+		)
+}
+
+func FailedResponsesPanel(queryString string, panelID uint32, promDatasource dashboard.DataSourceRef) *logs.PanelBuilder {
+	return logs.NewPanelBuilder().
+		Title("Failed responses").
+		Id(panelID).
+		Datasource(promDatasource).
+		Height(8).
+		Span(12).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`{` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} |~ "failed\":true"`).
+				LegendFormat("__auto"),
+		)
+}
+
+func TimedOutResponsesPanel(queryString string, panelID uint32, promDatasource dashboard.DataSourceRef) *logs.PanelBuilder {
+	return logs.NewPanelBuilder().
+		Title("Timed out responses").
+		Id(panelID).
+		Datasource(promDatasource).
+		Height(8).
+		Span(12).
+		Transparent(true).
+		WithTarget(
+			prometheus.NewDataqueryBuilder().
+				Expr(`{` + queryString + `go_test_name=~"${go_test_name:pipe}", test_data_type=~"responses", gen_name=~"${gen_name:pipe}"} |~ "timeout\":true"`).
+				LegendFormat("__auto"),
+		)
+}

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/go-resty/resty/v2 v2.11.0
 	github.com/google/uuid v1.3.1
 	github.com/grafana/dskit v0.0.0-20231120170505-765e343eda4f
+	github.com/grafana/grafana-foundation-sdk/go v0.0.0-20240326122733-6f96a993222b
 	// loki main 12/15/2023
 	github.com/grafana/loki v1.6.2-0.20231215164305-b51b7d7b5503
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/grafana/dskit v0.0.0-20231120170505-765e343eda4f h1:gyojr97YeWZ70pKNa
 github.com/grafana/dskit v0.0.0-20231120170505-765e343eda4f/go.mod h1:8dsy5tQOkeNQyjXpm5mQsbCu3H5uzeBD35MzRQFznKU=
 github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586 h1:/of8Z8taCPftShATouOrBVy6GaTTjgQd/VfNiZp/VXQ=
 github.com/grafana/gomemcache v0.0.0-20231023152154-6947259a0586/go.mod h1:PGk3RjYHpxMM8HFPhKKo+vve3DdlPUELZLSDEFehPuU=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20240326122733-6f96a993222b h1:Msqs1nc2qWMxTriDCITKl58Td+7Md/RURmUmH7RXKns=
+github.com/grafana/grafana-foundation-sdk/go v0.0.0-20240326122733-6f96a993222b/go.mod h1:WtWosval1KCZP9BGa42b8aVoJmVXSg0EvQXi9LDSVZQ=
 github.com/grafana/loki v1.6.2-0.20231215164305-b51b7d7b5503 h1:gdrsYbmk8822v6qvPwZO5DC6QjnAW7uKJ9YXnoUmV8c=
 github.com/grafana/loki v1.6.2-0.20231215164305-b51b7d7b5503/go.mod h1:d8seWXCEXkL42mhuIJYcGi6DxfehzoIpLrMQWJojvOo=
 github.com/grafana/loki/pkg/push v0.0.0-20231124142027-e52380921608 h1:ZYk42718kSXOiIKdjZKljWLgBpzL5z1yutKABksQCMg=


### PR DESCRIPTION
This PR adds wasp panels that use [Grafana Foundation SDK](https://github.com/grafana/grafana-foundation-sdk). The panels will be reused in Mercury test dashboards, etc.

Example dashboard https://grafana.ops.prod.cldev.sh/d/c6eee55d-8282-4f3e-9493-fd1a6392bbc5/mercury-load-tests-production-testnet?orgId=1&from=1711625607959&to=1711626059322